### PR TITLE
fix: correct archive nav link and bundle source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://mirrors.tuna.tsinghua.edu.cn/rubygems/'
+source 'https://rubygems.org'
 gem 'jekyll-paginate'
 
 gem "jekyll", "~> 4.0"

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -24,7 +24,7 @@
                             <a href="{{ site.baseurl }}/">Home</a>
                         </li>
                         <li>
-                            <a href="{{ site.baseurl }}/archive.html">Archive</a>
+                            <a href="{{ '/archive/' | prepend: site.baseurl }}">Archive</a>
                         </li>
                         {% for page in site.pages %}
                         {% if page.title and page.title != 'Archive' and page.hide-in-nav != true %}


### PR DESCRIPTION
## Summary
- fix archive navbar link to point to `/archive/` rather than `/archive.html`
- switch bundler source to `https://rubygems.org` for reliability

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898934ddde883229688c331f2a2c9ac